### PR TITLE
spec file for helm 3.0.1 rhose 4.3

### DIFF
--- a/openshift-helm.spec
+++ b/openshift-helm.spec
@@ -30,20 +30,15 @@ OpenShift helm is tool for managing Charts in OpenShif. Charts are packages of p
 %setup -q -n helm
 mkdir -p %{_builddir}/src/helm.sh
 rm -rf %{_builddir}/src/helm.sh/helm
-mv %{_builddir}/helm %{_builddir}/src/helm.sh
-cd %{_builddir}/src/helm.sh/helm
+cp -rf %{_builddir}/helm %{_builddir}/src/helm.sh
 
 %build
+cd %{_builddir}/src/helm.sh/helm
 TAG=%{helm_version} GOPATH=%{_builddir} make build-cross
 
 %install
-mkdir -p %{buildroot}/%{_bindir}
-install -m 0755 helm-linux-amd64 %{buildroot}/%{_bindir}/helm
-
-install -d %{buildroot}%{_datadir}/%{name}-redistributable/{linux,macos,windows}
-install -p -m 755 helm-linux-amd64 %{buildroot}%{_datadir}/%{name}-redistributable/linux/helm-linux-amd64
-install -p -m 755 helm-darwin-amd64 %{buildroot}/%{_datadir}/%{name}-redistributable/macos/helm-darwin-amd64
-install -p -m 755 helm-windows-amd64.exe %{buildroot}/%{_datadir}/%{name}-redistributable/windows/helm-windows-amd64.exe
+mkdir -p %{buildroot}%{_bindir}
+install -m 0755 %{_builddir}/src/helm.sh/helm/_dist/linux-amd64/helm %{buildroot}%{_bindir}
 
 %files
 %license LICENSE
@@ -61,12 +56,6 @@ Obsoletes:      %{package_name}-redistributable
 
 %files redistributable
 %license LICENSE
-%dir %{_datadir}/%{name}-redistributable/linux/
-%dir %{_datadir}/%{name}-redistributable/macos/
-%dir %{_datadir}/%{name}-redistributable/windows/
-%{_datadir}/%{name}-redistributable/linux/helm-linux-amd64
-%{_datadir}/%{name}-redistributable/macos/helm-darwin-amd64
-%{_datadir}/%{name}-redistributable/windows/helm-windows-amd64.exe
 
 %changelog
 * Thu Sep 05 2019 Bama Charan Kundu <bkundu@redhat.com> v3.0.1-1

--- a/openshift-helm.spec
+++ b/openshift-helm.spec
@@ -1,0 +1,70 @@
+#debuginfo not supported with Go
+%global debug_package %{nil}
+%global package_name helm
+%global product_name OpenShift Container Platform
+%global golang_version 1.12
+%global helm_version 3.0.1
+%global helm_release 1
+%global source_dir helm-v%{helm_version}-%{helm_release}
+%global source_tar %{source_dir}.tar.gz
+
+Name:           %{package_name}
+Version:        %{helm_version}
+Release:        %{helm_release}
+Summary:        %{product_name} helm binary for rhose 4.3
+License:        Apache License Version 2.0
+URL:            https://github.com/redhat-developer/helm/tree/rhose-4.3
+
+ExclusiveArch:  x86_64
+
+Source0:        %{source_tar}
+BuildRequires:  gcc
+BuildRequires:  golang >= %{golang_version}
+Provides:       %{package_name}
+Obsoletes:      %{package_name}
+
+%description
+OpenShift helm is tool for managing Charts in OpenShif. Charts are packages of pre-configured OpenShift Resources
+
+%prep
+%setup -q -n %{source_dir}
+
+%build
+TAG=%{helm_version} make build-cross
+
+%install
+mkdir -p %{buildroot}/%{_bindir}
+install -m 0755 helm-linux-amd64 %{buildroot}/%{_bindir}/helm
+
+install -d %{buildroot}%{_datadir}/%{name}-redistributable/{linux,macos,windows}
+install -p -m 755 helm-linux-amd64 %{buildroot}%{_datadir}/%{name}-redistributable/linux/helm-linux-amd64
+install -p -m 755 helm-darwin-amd64 %{buildroot}/%{_datadir}/%{name}-redistributable/macos/helm-darwin-amd64
+install -p -m 755 helm-windows-amd64.exe %{buildroot}/%{_datadir}/%{name}-redistributable/windows/helm-windows-amd64.exe
+
+%files
+%license LICENSE
+%{_bindir}/helm
+
+%package redistributable
+Summary:        %{product_name} helm binaries for Linux, Mac OSX, and Windows
+BuildRequires:  gcc
+BuildRequires:  golang >= %{golang_version}
+Provides:       %{package_name}-redistributable
+Obsoletes:      %{package_name}-redistributable
+
+%description redistributable
+%{product_name} helm cross platform binaries for Linux, macOS and Windows.
+
+%files redistributable
+%license LICENSE
+%dir %{_datadir}/%{name}-redistributable/linux/
+%dir %{_datadir}/%{name}-redistributable/macos/
+%dir %{_datadir}/%{name}-redistributable/windows/
+%{_datadir}/%{name}-redistributable/linux/helm-linux-amd64
+%{_datadir}/%{name}-redistributable/macos/helm-darwin-amd64
+%{_datadir}/%{name}-redistributable/windows/helm-windows-amd64.exe
+
+%changelog
+* Thu Sep 05 2019 Bama Charan Kundu <bkundu@redhat.com> v3.0.1-1
+- Initial tech preview release
+

--- a/openshift-helm.spec
+++ b/openshift-helm.spec
@@ -27,10 +27,14 @@ Obsoletes:      %{package_name}
 OpenShift helm is tool for managing Charts in OpenShif. Charts are packages of pre-configured OpenShift Resources
 
 %prep
-%setup -q -n %{source_dir}
+%setup -q -n helm
+mkdir -p %{_builddir}/src/helm.sh
+rm -rf %{_builddir}/src/helm.sh/helm
+mv %{_builddir}/helm %{_builddir}/src/helm.sh
+cd %{_builddir}/src/helm.sh/helm
 
 %build
-TAG=%{helm_version} make build-cross
+TAG=%{helm_version} GOPATH=%{_builddir} make build-cross
 
 %install
 mkdir -p %{buildroot}/%{_bindir}

--- a/openshift-helm.spec
+++ b/openshift-helm.spec
@@ -40,6 +40,14 @@ TAG=%{helm_version} GOPATH=%{_builddir} make build-cross
 mkdir -p %{buildroot}%{_bindir}
 install -m 0755 %{_builddir}/src/helm.sh/helm/_dist/linux-amd64/helm %{buildroot}%{_bindir}
 
+install -d %{buildroot}%{_datadir}/%{name}-redistributable/{linux-386,linux-arm,linux-arm64,linux-ppc64le,macos,windows}
+install -p -m 0755 %{_builddir}/src/helm.sh/helm/_dist/linux-386/helm %{buildroot}%{_datadir}/%{name}-redistributable/linux-386
+install -p -m 0755 %{_builddir}/src/helm.sh/helm/_dist/linux-arm/helm %{buildroot}%{_datadir}/%{name}-redistributable/linux-arm
+install -p -m 0755 %{_builddir}/src/helm.sh/helm/_dist/linux-arm64/helm %{buildroot}%{_datadir}/%{name}-redistributable/linux-arm64
+install -p -m 0755 %{_builddir}/src/helm.sh/helm/_dist/linux-ppc64le/helm %{buildroot}%{_datadir}/%{name}-redistributable/linux-ppc64le
+install -p -m 0755 %{_builddir}/src/helm.sh/helm/_dist/darwin-amd64/helm %{buildroot}%{_datadir}/%{name}-redistributable/macos
+install -p -m 0755 %{_builddir}/src/helm.sh/helm/_dist/windows-amd64/helm.exe %{buildroot}%{_datadir}/%{name}-redistributable/windows
+
 %files
 %license LICENSE
 %{_bindir}/helm
@@ -56,6 +64,18 @@ Obsoletes:      %{package_name}-redistributable
 
 %files redistributable
 %license LICENSE
+%dir %{_datadir}/%{name}-redistributable/linux-386
+%dir %{_datadir}/%{name}-redistributable/linux-arm
+%dir %{_datadir}/%{name}-redistributable/linux-arm64
+%dir %{_datadir}/%{name}-redistributable/linux-ppc64le
+%dir %{_datadir}/%{name}-redistributable/macos
+%dir %{_datadir}/%{name}-redistributable/windows
+%{_datadir}/%{name}-redistributable/linux-386/helm
+%{_datadir}/%{name}-redistributable/linux-arm/helm
+%{_datadir}/%{name}-redistributable/linux-arm64/helm
+%{_datadir}/%{name}-redistributable/linux-ppc64le/helm
+%{_datadir}/%{name}-redistributable/macos/helm
+%{_datadir}/%{name}-redistributable/windows/helm.exe
 
 %changelog
 * Thu Sep 05 2019 Bama Charan Kundu <bkundu@redhat.com> v3.0.1-1


### PR DESCRIPTION
In this PR 
* We are creating the SPEC file for generating RPM for helm-3.0.1
* we are building the binary in $GOPATH/src/helm.sh/helm
* helm_verion is set to 3.0.1 (as we are building this for tech preview)
* helm_release is set to 1 for the first build try in brew
* go dependency is set to >=1.12

Run the spec file locally with rpmbuild
```
$ rpmdev-setuptree
$ cp openshift-helm.spec rpmbuild/SPECS/
```
create tar of the source code and put in the sources 
```
$tar -cvf helm-v3.0.1-1.tar.gz helm
$cp helm-v3.0.1-1.tar.gz rpmbuild/SOURCES/
```
then build the rpm
```
$rpmbuild -bb rpmbuild/SPECS/openshift-helm.spec
```

after the build two RPMs should be there
```
$ tree rpmbuild/RPMS/
RPMS/
└── x86_64
    ├── helm-3.0.1-1.x86_64.rpm
    └── helm-redistributable-3.0.1-1.x86_64.rpm

```
you can try out the rpm by installing it
```
$sudo rpm -ivh rpmbuild/RPMS/x86_64/helm-3.0.1-1.x86_64.rpm
```
