### PR TITLE
Set GOCACHE env variable in the Dockerfile.tests

### DIFF
--- a/openshift-ci/Dockerfile.tests
+++ b/openshift-ci/Dockerfile.tests
@@ -8,6 +8,7 @@ ENV LANG=en_US.utf8
 ENV GOPATH /tmp/go
 ARG GOROOT_BASE=/tmp/goroot
 ENV GOROOT $GOROOT_BASE/go
+ENV GOCACHE=$GOROOT_BASE/.gocache
 ENV PATH=:$GOPATH/bin:$GOROOT/bin:$PATH
 
 ARG GO_PACKAGE_PATH=github.com/redhat-developer/helm


### PR DESCRIPTION
This PR fixes the:
* `failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied` image issue in OpenShift CI
* follow-up to https://github.com/redhat-developer/helm/pull/19