### PR TITLE
Add make target to create user to run the unit tests with it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,14 @@ test: TESTFLAGS += -race -v
 test: test-style
 test: test-unit
 
+.PHONY: add-test-user-with-uid
+add-test-user-with-uid:
+	$(eval UID := $(shell set | grep ^UID | cut -d "=" -f2))
+	@-echo huser:x:$(UID):$(UID):Helm User:/tmp:/sbin/nologin >> /etc/passwd
+	@-echo huser:x:$(UID):huser >> /etc/group
+
 .PHONY: test-unit
-test-unit:
+test-unit: add-test-user-with-uid
 	@echo
 	@echo "==> Running unit tests <=="
 	GO111MODULE=on go test $(GOFLAGS) -run $(TESTS) $(PKG) $(TESTFLAGS)


### PR DESCRIPTION
The unit tests are executed in a container under random-like user id (e.g. `1026310000`) and part of the codebase tries to get the user's information based on that `UID`. Since the user with such id does not exist in the container a test error occurs complaining about non-existing user. This PR 