### PR TITLE
feat(install): introduce --disable-openapi-validation

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -140,6 +140,7 @@ func addInstallFlags(f *pflag.FlagSet, client *action.Install, valueOpts *values
 	f.BoolVar(&client.Atomic, "atomic", false, "if set, installation process purges chart on fail. The --wait flag will be set automatically if --atomic is used")
 	f.BoolVar(&client.SkipCRDs, "skip-crds", false, "if set, no CRDs will be installed. By default, CRDs are installed if not already present")
 	f.BoolVar(&client.SubNotes, "render-subchart-notes", false, "if set, render subchart notes along with the parent")
+	f.BoolVar(&client.DisableOpenAPIValidation, "disable-openapi-validation", false, "if set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema")
 	addValueOptionsFlags(f, valueOpts)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 }

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -83,6 +83,7 @@ type Install struct {
 	Atomic           bool
 	SkipCRDs         bool
 	SubNotes         bool
+	DisableOpenAPIValidation bool
 	// APIVersions allows a manual set of supported API Versions to be passed
 	// (for things like templating). These are ignored if ClientOnly is false
 	APIVersions chartutil.VersionSet
@@ -226,7 +227,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	// Mark this release as in-progress
 	rel.SetStatus(release.StatusPendingInstall, "Initial install underway")
 
-	resources, err := i.cfg.KubeClient.Build(bytes.NewBufferString(rel.Manifest), true)
+	resources, err := i.cfg.KubeClient.Build(bytes.NewBufferString(rel.Manifest), !i.DisableOpenAPIValidation)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to build kubernetes objects from release manifest")
 	}


### PR DESCRIPTION
This PR introduces additional flag for `helm install` to ignore OpenAPI schema validation.

Upstream https://github.com/helm/helm/pull/6819
This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1773682