### PR TITLE
fs_test.go: Assume non-root user instead of failing the test.

### DIFF
--- a/internal/third_party/dep/fs/fs_test.go
+++ b/internal/third_party/dep/fs/fs_test.go
@@ -178,10 +178,8 @@ func TestCopyDirFail_SrcInaccessible(t *testing.T) {
 	var currentUser, err = user.Current()
 
 	if err != nil {
-		t.Fatalf("Failed to get name of current user: %s", err)
-	}
-
-	if currentUser.Name == "root" {
+		t.Logf("Failed to get name of current user, assuming non-root. %s", err)
+	} else if currentUser.Name == "root" {
 		// Skipping if root, because all files are accessible
 		t.Skip("Skipping for root user")
 	}
@@ -217,10 +215,8 @@ func TestCopyDirFail_DstInaccessible(t *testing.T) {
 	var currentUser, err = user.Current()
 
 	if err != nil {
-		t.Fatalf("Failed to get name of current user: %s", err)
-	}
-
-	if currentUser.Name == "root" {
+		t.Logf("Failed to get name of current user, assuming non-root. %s", err)
+	} else if currentUser.Name == "root" {
 		// Skipping if root, because all files are accessible
 		t.Skip("Skipping for root user")
 	}
@@ -317,10 +313,8 @@ func TestCopyDirFailOpen(t *testing.T) {
 	var currentUser, err = user.Current()
 
 	if err != nil {
-		t.Fatalf("Failed to get name of current user: %s", err)
-	}
-
-	if currentUser.Name == "root" {
+		t.Logf("Failed to get name of current user, assuming non-root. %s", err)
+	} else if currentUser.Name == "root" {
 		// Skipping if root, because all files are accessible
 		t.Skip("Skipping for root user")
 	}
@@ -486,10 +480,8 @@ func TestCopyFileFail(t *testing.T) {
 	var currentUser, err = user.Current()
 
 	if err != nil {
-		t.Fatalf("Failed to get name of current user: %s", err)
-	}
-
-	if currentUser.Name == "root" {
+		t.Logf("Failed to get name of current user, assuming non-root. %s", err)
+	} else if currentUser.Name == "root" {
 		// Skipping if root, because all files are accessible
 		t.Skip("Skipping for root user")
 	}
@@ -577,10 +569,8 @@ func TestIsDir(t *testing.T) {
 	var currentUser, err = user.Current()
 
 	if err != nil {
-		t.Fatalf("Failed to get name of current user: %s", err)
-	}
-
-	if currentUser.Name == "root" {
+		t.Logf("Failed to get name of current user, assuming non-root. %s", err)
+	} else if currentUser.Name == "root" {
 		// Skipping if root, because all files are accessible
 		t.Skip("Skipping for root user")
 	}
@@ -634,10 +624,8 @@ func TestIsSymlink(t *testing.T) {
 	var currentUser, err = user.Current()
 
 	if err != nil {
-		t.Fatalf("Failed to get name of current user: %s", err)
-	}
-
-	if currentUser.Name == "root" {
+		t.Logf("Failed to get name of current user, assuming non-root. %s", err)
+	} else if currentUser.Name == "root" {
 		// Skipping if root, because all files are accessible
 		t.Skip("Skipping for root user")
 	}


### PR DESCRIPTION
When the unit tests are run in a container as a random-like user ID (e.g. in Kubernetes or OpenShift) or the user ID is not mentioned in `/etc/passwd` the tests fail complaining like:
```
--- FAIL: TestCopyDirFail_SrcInaccessible (0.00s)
    fs_test.go:181: Failed to get name of current user: user: unknown userid 1026330000
--- FAIL: TestCopyDirFail_DstInaccessible (0.00s)
    fs_test.go:220: Failed to get name of current user: user: unknown userid 1026330000
--- FAIL: TestCopyDirFailOpen (0.00s)
    fs_test.go:320: Failed to get name of current user: user: unknown userid 1026330000
--- FAIL: TestCopyFileFail (0.00s)
    fs_test.go:489: Failed to get name of current user: user: unknown userid 1026330000
--- FAIL: TestIsDir (0.00s)
    fs_test.go:580: Failed to get name of current user: user: unknown userid 1026330000
--- FAIL: TestIsSymlink (0.00s)
    fs_test.go:637: Failed to get name of current user: user: unknown userid 1026330000
```

The `currentUser` here is really only used to check if it is `root` and the very same function that is used here to get the current user (`user.Current()`) is not used anywhere else in the codebase. It should be sufficient to try to get the current user and if that fails, assume the user is a non-root and go on without actually failing the unit test.

This makes the unit tests less flaky.