### PR TITLE
[WIP]Fix 'no such file ... /.cache/...' for unit tests on OpenShift CI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 _dist/
 bin/
 vendor/
+.cache

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ test: test-unit
 test-unit:
 	@echo
 	@echo "==> Running unit tests <=="
-	GO111MODULE=on go test $(GOFLAGS) -run $(TESTS) $(PKG) $(TESTFLAGS)
+	GO111MODULE=on XDG_CACHE_HOME=$(PWD)/.cache go test $(GOFLAGS) -run $(TESTS) $(PKG) $(TESTFLAGS)
 
 .PHONY: test-coverage
 test-coverage:


### PR DESCRIPTION
This PR fixes the following problem with unit tests when running in OpenShift CI:
```
--- FAIL: TestFindChartInRepoURL (0.01s)
    chartrepo_test.go:288: looks like "http://127.0.0.1:34103" is not a valid chart repository or cannot be reached: open /.cache/helm/repository/iiEOCiAu0Yxv5fuUJqIFkIfKR+g=-index.yaml: no such file or directory
```
This is caused by basing the XDG cache home directory on `$HOME` variable - which is set to `/` in the CI's container - for a case where the `XDG_CACHE_HOME` is not set.

This PR fixes the issue by setting the `XDG_CACHE_HOME` variable for the unit tests directly.
---
NOTE:
This can be also achieved by the combination of:
* https://github.com/redhat-developer/helm/pull/9, and
* https://github.com/openshift/release/pull/5913


