### PR TITLE
Set GOCACHE and XDG_CACHE_HOME for OpenShift CI.

### DIFF
--- a/openshift-ci/.gitignore
+++ b/openshift-ci/.gitignore
@@ -1,0 +1,2 @@
+.gocache
+.xdg-cache

--- a/openshift-ci/Makefile
+++ b/openshift-ci/Makefile
@@ -2,15 +2,14 @@
 
 include ./Makefile
 
+export GOCACHE := $(PWD)/openshift-ci/.gocache
+export XDG_CACHE_HOME := $(PWD)/openshift-ci/.xdg-cache
+
 $(GOLANGCI_LINT):
 	(cd /; GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@master)
 
 .PHONY: lint
 lint: test-style
 
-.PHONY: -xdg-cache-home
--xdg-cache-home:
-	$(eval export XDG_CACHE_HOME := $(PWD)/.cache)
-
 .PHONY: unit
-unit: -xdg-cache-home test-unit
+unit: test-unit


### PR DESCRIPTION
This PR fixes the following problem with unit tests when running in OpenShift CI:
```
--- FAIL: TestFindChartInRepoURL (0.01s)
    chartrepo_test.go:288: looks like "http://127.0.0.1:34103" is not a valid chart repository or cannot be reached: open /.cache/helm/repository/iiEOCiAu0Yxv5fuUJqIFkIfKR+g=-index.yaml: no such file or directory
```
This is caused by basing the XDG cache home directory on `$HOME` variable - which is set to `/` in the CI's container - for a case where the `XDG_CACHE_HOME` is not set.

This PR:
* Fixes the issue above by setting the `XDG_CACHE_HOME` variable for the unit tests directly.
* Sets `GOCACHE` variable for OpenShift CI the same way as above