### PR TITLE
Enable ppc64le and s390x binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINDIR     := $(CURDIR)/bin
 DIST_DIRS  := find * -type d -exec
-TARGETS    := darwin/amd64 linux/amd64 linux/386 linux/arm linux/arm64 linux/ppc64le windows/amd64
+TARGETS    := darwin/amd64 linux/amd64 linux/386 linux/arm linux/arm64 linux/ppc64le linux/s390x windows/amd64
 BINNAME    ?= helm
 
 GOPATH        = $(shell go env GOPATH)

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,8 @@ build-cross:
 	GO111MODULE=on CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -mod=vendor -o "_dist/linux-amd64/$(BINNAME)" $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
 	GO111MODULE=on CGO_ENABLED=0 GOARCH=amd64 GOOS=darwin go build -mod=vendor -o "_dist/darwin-amd64/$(BINNAME)" $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
 	GO111MODULE=on CGO_ENABLED=0 GOARCH=amd64 GOOS=windows go build -mod=vendor -o "_dist/windows-amd64/$(BINNAME).exe" $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
+	GO111MODULE=on CGO_ENABLED=0 GOARCH=ppc64le GOOS=linux go build -mod=vendor -o "_dist/linux-ppc64le/$(BINNAME)" $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
+	GO111MODULE=on CGO_ENABLED=0 GOARCH=s390x GOOS=linux go build -mod=vendor -o "_dist/linux-s390x/$(BINNAME)" $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
 
 .PHONY: dist
 dist:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ DEP           = $(GOPATH)/bin/dep
 GOX           = $(GOPATH)/bin/gox
 GOIMPORTS     = $(GOPATH)/bin/goimports
 GOLANGCI_LINT = $(GOPATH)/bin/golangci-lint
+ARCH          = $(shell uname -p)
 
 ACCEPTANCE_DIR:=$(GOPATH)/src/helm.sh/acceptance-testing
 # To specify the subset of acceptance tests to run. '.' means all tests
@@ -67,7 +68,11 @@ $(BINDIR)/$(BINNAME): $(SRC)
 
 .PHONY: test
 test: build
+ifeq ($(ARCH),s390x)
+test: TESTFLAGS += -v
+else
 test: TESTFLAGS += -race -v
+endif
 test: test-style
 test: test-unit
 

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -87,6 +87,8 @@ func TestPlatformPrepareCommand(t *testing.T) {
 			PlatformCommand: []PlatformCommand{
 				{OperatingSystem: "linux", Architecture: "i386", Command: "echo -n linux-i386"},
 				{OperatingSystem: "linux", Architecture: "amd64", Command: "echo -n linux-amd64"},
+				{OperatingSystem: "linux", Architecture: "arm64", Command: "echo -n linux-arm64"},
+				{OperatingSystem: "linux", Architecture: "ppc64le", Command: "echo -n linux-ppc64le"},
 				{OperatingSystem: "linux", Architecture: "s390x", Command: "echo -n linux-s390x"},
 				{OperatingSystem: "windows", Architecture: "amd64", Command: "echo -n win-64"},
 			},
@@ -99,6 +101,10 @@ func TestPlatformPrepareCommand(t *testing.T) {
 		osStrCmp = "linux-i386"
 	} else if os == "linux" && arch == "amd64" {
 		osStrCmp = "linux-amd64"
+	} else if os == "linux" && arch == "arm64" {
+		osStrCmp = "linux-arm64"
+	} else if os == "linux" && arch == "ppc64le" {
+		osStrCmp = "linux-ppc64le"
 	} else if os == "linux" && arch == "s390x" {
 		osStrCmp = "linux-s390x"
 	} else if os == "windows" && arch == "amd64" {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -87,6 +87,7 @@ func TestPlatformPrepareCommand(t *testing.T) {
 			PlatformCommand: []PlatformCommand{
 				{OperatingSystem: "linux", Architecture: "i386", Command: "echo -n linux-i386"},
 				{OperatingSystem: "linux", Architecture: "amd64", Command: "echo -n linux-amd64"},
+				{OperatingSystem: "linux", Architecture: "s390x", Command: "echo -n linux-s390x"},
 				{OperatingSystem: "windows", Architecture: "amd64", Command: "echo -n win-64"},
 			},
 		},
@@ -98,6 +99,8 @@ func TestPlatformPrepareCommand(t *testing.T) {
 		osStrCmp = "linux-i386"
 	} else if os == "linux" && arch == "amd64" {
 		osStrCmp = "linux-amd64"
+	} else if os == "linux" && arch == "s390x" {
+		osStrCmp = "linux-s390x"
 	} else if os == "windows" && arch == "amd64" {
 		osStrCmp = "win-64"
 	} else {


### PR DESCRIPTION
With OCP4 shipping for IBM Z and coming for Power LE, IBM is requesting feature parity wrt availability of helm binaries on their architectures.  The first three of these commits are backports/cherry-picks from upstream, the last is downstream-specific.