### PR TITLE
Set the version of golangci-lint binary to the same as in upstream.

### DIFF
--- a/openshift-ci/Makefile
+++ b/openshift-ci/Makefile
@@ -6,10 +6,10 @@ export GOCACHE := $(PWD)/openshift-ci/.gocache
 export XDG_CACHE_HOME := $(PWD)/openshift-ci/.xdg-cache
 
 $(GOLANGCI_LINT):
-	(cd /; GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@master)
+	(cd /; GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.21.0)
 
 .PHONY: lint
-lint: test-style
+lint: $(GOLANGCI_LINT) test-style
 
 .PHONY: unit
 unit: test-unit

--- a/openshift-ci/Makefile
+++ b/openshift-ci/Makefile
@@ -14,7 +14,7 @@ $(GOLANGCI_LINT):
 	rm -rf golangci-lint-$(GOLANGCI_LINT_VERSION)-linux-amd64
 
 .PHONY: lint
-lint: test-style
+lint: $(GOLANGCI_LINT) test-style
 
 .PHONY: unit
 unit: test-unit

--- a/openshift-ci/Makefile
+++ b/openshift-ci/Makefile
@@ -5,11 +5,16 @@ include ./Makefile
 export GOCACHE := $(PWD)/openshift-ci/.gocache
 export XDG_CACHE_HOME := $(PWD)/openshift-ci/.xdg-cache
 
+export GOLANGCI_LINT_VERSION := 1.21.0
+
 $(GOLANGCI_LINT):
-	(cd /; GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.21.0)
+	cd /
+	curl -sSL https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION)/golangci-lint-$(GOLANGCI_LINT_VERSION)-linux-amd64.tar.gz | tar xz
+	mv golangci-lint-$(GOLANGCI_LINT_VERSION)-linux-amd64/golangci-lint $(GOLANGCI_LINT)
+	rm -rf golangci-lint-$(GOLANGCI_LINT_VERSION)-linux-amd64
 
 .PHONY: lint
-lint: $(GOLANGCI_LINT) test-style
+lint: test-style
 
 .PHONY: unit
 unit: test-unit


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets the version of `golangci-lint` binary to the same as in upstream (`v1.21.0`).
**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation: self-explanatory Makefile
- [x] this PR does not need unit tests
- [x] this PR has been tested for backwards compatibility
