### PR TITLE
Sync go version with upstream CI (1.13.8) and change ubi base image to v8.

### DIFF
--- a/openshift-ci/Dockerfile.tests
+++ b/openshift-ci/Dockerfile.tests
@@ -1,7 +1,7 @@
-FROM registry.access.redhat.com/ubi7/ubi:latest
+FROM registry.redhat.io/ubi8/ubi:latest
 
 ARG GO_PACKAGE_PATH=github.com/redhat-developer/helm
-ARG GO_VERSION=1.13.1
+ARG GO_VERSION=1.13.8
 
 ENV GIT_COMMITTER_NAME      devtools
 ENV GIT_COMMITTER_EMAIL     devtools@redhat.com


### PR DESCRIPTION
**What this PR does / why we need it**:
Upstream CI uses `v1.13.8` version of go and RH releases are based on RHEL8.
This PR updates the `Dockerfile.tests` file that is used for images on OpenShift CI.

**Special notes for your reviewer**:
The `ci/prow/*` checking works in a way that it uses `root` image taken from `master` and only then builds the `src` image where it pulls the PR to test. That is why the updates to the `root` image (`Dockerfile.tests`) are not covered by the PR checks and are expected to fail internally.

**If applicable**:
- [x] this PR does not need unit tests
- [x] this PR has been tested for backward compatibility
