### PR TITLE
Fix OpenShift CI base image registry.

### DIFF
--- a/openshift-ci/Dockerfile.tests
+++ b/openshift-ci/Dockerfile.tests
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi8/ubi:latest
 
 ARG GO_PACKAGE_PATH=github.com/redhat-developer/helm
 ARG GO_VERSION=1.13.8


### PR DESCRIPTION
**What this PR does / why we need it**:
`registry.redhat.io` requires authentication that is not provided on OpenShift CI.  Changing it back to 
`registry.access.redhat.com`.

**Special notes for your reviewer**:
The ci/prow/* checking works in a way that it uses root image taken from master and only then builds the src image where it pulls the PR to test. That is why the updates to the root image (Dockerfile.tests) are not covered by the PR checks and are expected to fail internally.
