### PR TITLE
Update the openshift-ci/Makefile to make the Makefile.acceptance obsolete

### DIFF
--- a/openshift-ci/Dockerfile.tests
+++ b/openshift-ci/Dockerfile.tests
@@ -13,7 +13,7 @@ ENV GOCACHE                 /tmp/.gocache
 
 ENV PATH                    $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN yum install -y --quiet --setopt=skip_missing_names_on_install=False \
+RUN yum install -y \
     git \
     make \
     gcc \

--- a/openshift-ci/Makefile
+++ b/openshift-ci/Makefile
@@ -7,6 +7,11 @@ export XDG_CACHE_HOME := $(PWD)/openshift-ci/.xdg-cache
 
 export GOLANGCI_LINT_VERSION := 1.21.0
 
+export ACCEPTANCE_DIR := $(CURDIR)/acceptance-testing
+export ACCEPTANCE_RUN_TESTS := repos.robot
+export ROBOT_HELM_V3 := 1
+export ROBOT_DEBUG_LEVEL := 3
+
 $(GOLANGCI_LINT):
 	cd /
 	curl -sSL https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION)/golangci-lint-$(GOLANGCI_LINT_VERSION)-linux-amd64.tar.gz | tar xz


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the `openshift-ci/Makefile` to make the `Makefile.acceptance` obsolete.

**Special notes for your reviewer**:
-
