### PR TITLE
Pull latest changes of acceptance-tests in the Dockerfile.tests instead of failing the clone if repo dir exists.

### DIFF
--- a/openshift-ci/Dockerfile.tests
+++ b/openshift-ci/Dockerfile.tests
@@ -38,6 +38,6 @@ WORKDIR ${GOPATH}/src/${GO_PACKAGE_PATH}
 
 COPY . .
 
-RUN git clone --depth=1 https://github.com/ldimaggi/acceptance-testing.git
+RUN if [ ! -d 'acceptance-testing' ]; then git clone --depth=1 https://github.com/ldimaggi/acceptance-testing.git acceptance-testing; else cd acceptance-testing; git pull; fi
 
 RUN chmod -R go+wr $GOPATH $GOCACHE /etc/passwd /etc/group


### PR DESCRIPTION
**What this PR does / why we need it**:

Pull latest changes of `acceptance-tests` in the `Dockerfile.tests` instead of failing the clone if repo dir exists.

