### PR TITLE
Add linux/arm64 to build-cross

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ build-cross:
 	GO111MODULE=on CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -mod=vendor -o "_dist/linux-amd64/$(BINNAME)" $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
 	GO111MODULE=on CGO_ENABLED=0 GOARCH=amd64 GOOS=darwin go build -mod=vendor -o "_dist/darwin-amd64/$(BINNAME)" $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
 	GO111MODULE=on CGO_ENABLED=0 GOARCH=amd64 GOOS=windows go build -mod=vendor -o "_dist/windows-amd64/$(BINNAME).exe" $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
+	GO111MODULE=on CGO_ENABLED=0 GOARCH=arm64 GOOS=linux go build -mod=vendor -o "_dist/linux-arm64/$(BINNAME)" $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
 	GO111MODULE=on CGO_ENABLED=0 GOARCH=ppc64le GOOS=linux go build -mod=vendor -o "_dist/linux-ppc64le/$(BINNAME)" $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
 	GO111MODULE=on CGO_ENABLED=0 GOARCH=s390x GOOS=linux go build -mod=vendor -o "_dist/linux-s390x/$(BINNAME)" $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/helm
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a precursor to adding a linux/arm64 (aarch64) binary to our helm packages.

**Special notes for your reviewer**:
make test-unit passes on aarch64.
